### PR TITLE
reintroduce -Ofast, delegate stripping to the compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL = /bin/sh
 
-REQ_CFLAGS = --std=c99 -fPIC
+REQ_CFLAGS = --std=c99 -fPIC -s
 WARN_CFLAGS = -Wall -Wextra
-CFLAGS ?= -O2 -flto -pipe
+CFLAGS ?= -Ofast -flto -pipe
 ACTUAL_CFLAGS = $(REQ_CFLAGS) $(WARN_CFLAGS) $(CFLAGS)
 
 DESTDIR ?= /
@@ -19,11 +19,9 @@ default: bottom-encode bottom-decode
 
 bottom-encode:
 	$(CC) $(ACTUAL_CFLAGS) bottom-encode.c -o bottom-encode
-	$(STRIP) ./bottom-encode
 
 bottom-decode:
 	$(CC) $(ACTUAL_CFLAGS) bottom-decode.c -o bottom-decode
-	$(STRIP) ./bottom-decode
 
 
 install: default


### PR DESCRIPTION
the previous pr removed `-Ofast` and improved the makefile in other ways, however, I am of the opinion that replacing -Ofast does not serve any purpose.

reasoning:
- I have tested `-Ofast` with bottom-c on x86, x86-64, and ARM 7. None suffered from any issues whatsoever. 
- delegating stripping to the compiler removes the need to call strip separately, speeding up compilation times.